### PR TITLE
Add toggle button in Demo

### DIFF
--- a/src/test/java/org/concordion/ext/demo/selenium/LoggingTooltipDemo.java
+++ b/src/test/java/org/concordion/ext/demo/selenium/LoggingTooltipDemo.java
@@ -1,8 +1,9 @@
 package org.concordion.ext.demo.selenium;
 
-import org.concordion.api.extension.Extensions;
+import org.concordion.api.extension.Extension;
 import org.concordion.ext.LoggingTooltipExtension;
 import org.concordion.ext.demo.selenium.web.GoogleResultsPage;
+import org.concordion.ext.tooltip.TooltipButton;
 import org.concordion.integration.junit4.ConcordionRunner;
 import org.junit.runner.RunWith;
 
@@ -18,13 +19,18 @@ import org.junit.runner.RunWith;
  * Run this class as a JUnit test to produce the Concordion results.
  */
 @RunWith(ConcordionRunner.class)
-@Extensions(LoggingTooltipExtension.class)
 public class LoggingTooltipDemo extends GoogleFixture {
 	
  	GoogleResultsPage resultsPage;
+ 	TooltipButton toggleButton;
+ 	
+ 	@Extension
+ 	public LoggingTooltipExtension extension = new LoggingTooltipExtension();
 
  	public LoggingTooltipDemo() {
         super(true);
+        toggleButton = new ToggleTooltipButton();
+        extension.setTooltipButton(toggleButton);
     }
     
 	/**
@@ -39,5 +45,17 @@ public class LoggingTooltipDemo extends GoogleFixture {
 	 */
 	public String getCalculatorResult() {
 		return resultsPage.getCalculatorResult();
+	}
+	
+	/**
+	 * Hides tooltips if parameter is not empty
+	 */
+	public void hideTooltip(String tooltipHidden) {
+		boolean displayTooltip = true;
+		if(tooltipHidden != null) {
+			// Tooltip is hidden only if param is set and not empty
+			displayTooltip = tooltipHidden.isEmpty();
+		}
+		extension.toggleTooltip(displayTooltip);
 	}
 }

--- a/src/test/java/org/concordion/ext/demo/selenium/ToggleTooltipButton.java
+++ b/src/test/java/org/concordion/ext/demo/selenium/ToggleTooltipButton.java
@@ -1,0 +1,40 @@
+package org.concordion.ext.demo.selenium;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.concordion.ext.tooltip.TooltipButton;
+
+public class ToggleTooltipButton implements TooltipButton {
+
+    private List<ActionListener> actionListeners;
+    
+    public ToggleTooltipButton() {
+        actionListeners = new ArrayList<ActionListener>();
+    }
+    
+    @Override
+    public void addActionListener(ActionListener l) {
+        actionListeners.add(l);
+        
+    }
+    
+    @Override
+    public void removeActionListener(ActionListener l) {
+        actionListeners.remove(l);
+    }
+    
+    @Override
+    public ActionListener[] getActionListeners() {
+        ActionListener[] listenersArray = new ActionListener[actionListeners.size()];
+        return actionListeners.toArray(listenersArray);
+    }
+    
+    public void processActionEvent(ActionEvent e) {
+        for(ActionListener a : actionListeners) {
+            a.actionPerformed(e);
+        }
+    }
+}

--- a/src/test/resources/org/concordion/ext/demo/selenium/LoggingTooltipDemo.html
+++ b/src/test/resources/org/concordion/ext/demo/selenium/LoggingTooltipDemo.html
@@ -1,32 +1,22 @@
 <html xmlns:c="http://www.concordion.org/2007/concordion">
 <link href="../../concordion.css" rel="stylesheet" type="text/css" />
-
-<script>
-    function toggleTooltip() {
-        var tooltips = document.querySelectorAll('a.tt');
-        for(var i in tooltips) {
-            if(tooltips[i].style.display == 'none') {
-                tooltips[i].style.display = 'initial';
-                document.getElementById('tooltipButton').value = "Hide tooltip";
-            } else {
-                tooltips[i].style.display = 'none';
-                document.getElementById('tooltipButton').value = "Show tooltip";
-            }
-        }
-    }
-</script>
-
 <body>
 
 <h1>Google Calculator</h1>
 
 <p>Google acts as a calculator if you enter a sum.</p> 
 
+<!-- Optional: it is possible to hide tooltips by setting #tooltipHidden variable -->
+<div style="display: none;">
+  <span c:set="#tooltipHidden"></span>
+</div>
+
 <div class="example">
 <h4>Example</h4>
 <p>Googling "<span c:execute="searchFor(#TEXT)">11 * 12</span>" displays "<span c:assertEquals="getCalculatorResult()">132</span>".</p>
 <p style="font-style: italic;">(Hover over the i icons to see the logging.)</p>
-<input type="button" id="tooltipButton" value="Hide tooltip" onclick="toggleTooltip();" />
+<br />
+<input type="button" c:execute="hideTooltip(#tooltipHidden)" onclick="toggleTooltip();" value="Toggle tooltip" />
 </div>
 
 </body>

--- a/src/test/resources/org/concordion/ext/demo/selenium/LoggingTooltipDemo.html
+++ b/src/test/resources/org/concordion/ext/demo/selenium/LoggingTooltipDemo.html
@@ -1,5 +1,21 @@
 <html xmlns:c="http://www.concordion.org/2007/concordion">
 <link href="../../concordion.css" rel="stylesheet" type="text/css" />
+
+<script>
+    function toggleTooltip() {
+        var tooltips = document.querySelectorAll('a.tt');
+        for(var i in tooltips) {
+            if(tooltips[i].style.display == 'none') {
+                tooltips[i].style.display = 'initial';
+                document.getElementById('tooltipButton').value = "Hide tooltip";
+            } else {
+                tooltips[i].style.display = 'none';
+                document.getElementById('tooltipButton').value = "Show tooltip";
+            }
+        }
+    }
+</script>
+
 <body>
 
 <h1>Google Calculator</h1>
@@ -10,6 +26,7 @@
 <h4>Example</h4>
 <p>Googling "<span c:execute="searchFor(#TEXT)">11 * 12</span>" displays "<span c:assertEquals="getCalculatorResult()">132</span>".</p>
 <p style="font-style: italic;">(Hover over the i icons to see the logging.)</p>
+<input type="button" id="tooltipButton" value="Hide tooltip" onclick="toggleTooltip();" />
 </div>
 
 </body>


### PR DESCRIPTION
Update Demo with the new feature: show/hide tooltips with a button
(See [pull request #3](https://github.com/concordion/concordion-logging-tooltip-extension/pull/3) in `concordion-logging-tooltip-extension` repo)